### PR TITLE
Gemspec: Allow Bundler 2.0 also

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ PLATFORMS
 DEPENDENCIES
   async-rspec (~> 1.0)
   async-worker!
-  bundler (~> 1.16)
+  bundler (>= 1.16)
   rake (~> 10.0)
   rspec (~> 3.0)
 

--- a/async-worker.gemspec
+++ b/async-worker.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 	
 	spec.add_development_dependency "async-rspec", "~> 1.0"
 	
-	spec.add_development_dependency "bundler", "~> 1.16"
+	spec.add_development_dependency "bundler", ">= 1.16"
 	spec.add_development_dependency "rake", "~> 10.0"
 	spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
This PR is a follow-up to #1: Unpin the Bundler from "only 1.x" to "anything 1.16 and above".