### PR TITLE
gemspec: Drop removed property has_rdoc

### DIFF
--- a/async-worker.gemspec
+++ b/async-worker.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |spec|
 	spec.executables = spec.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
 	spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
 	spec.require_paths = ["lib"]
-	spec.has_rdoc = "yard"
 
 	spec.add_dependency 'async', '~> 1.0'
 	spec.add_dependency 'async-io', '~> 1.3'


### PR DESCRIPTION
This PR removes a gemspec property which emits a warning about it having no effect.

```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /Users/olle/opensource/async-worker/async-worker.gemspec:17.
```

I searched the whole organisation, and this was the last one of `has_rdoc`s in gemspecs.