### PR TITLE
Ruby 2.2 lacks Thread::Queue#close

### DIFF
--- a/lib/async/worker/pool.rb
+++ b/lib/async/worker/pool.rb
@@ -35,7 +35,7 @@ module Async
 			end
 			
 			def close
-				@queue.close
+				@queue.close if @queue.respond_to?(:close)
 				@threads.each(&:join)
 			end
 			


### PR DESCRIPTION
This PR adds a check "can we call the #close method?" before doing that to a Queue.

I read the API documentation on Queue after seeing [this failure](https://travis-ci.com/socketry/async-worker/jobs/274161207#L518), and it seems that Ruby 2.3 has it, whereas 2.2 does not.

```
1) Async::Worker can execute work in parallel
     Failure/Error: @queue.close

     NoMethodError:
       undefined method `close' for #<Thread::Queue:0x00000001be8b28>
     # ./lib/async/worker/pool.rb:38:in `close'
     # ./spec/async/worker_spec.rb:28:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.2.0/gems/async-rspec-1.3.1/lib/async/rspec/reactor.rb:34:in `block (2 levels) in run_reactor'
     # ./vendor/bundle/ruby/2.2.0/gems/async-1.5.0/lib/async/reactor.rb:243:in `timeout'
     # ./vendor/bundle/ruby/2.2.0/gems/async-rspec-1.3.1/lib/async/rspec/reactor.rb:33:in `block in run_reactor'
     # ./vendor/bundle/ruby/2.2.0/gems/async-1.5.0/lib/async/task.rb:74:in `block in initialize'
```